### PR TITLE
Replace data loaders to LightningDataModule

### DIFF
--- a/project/lit_mnist.py
+++ b/project/lit_mnist.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 import torch
 import pytorch_lightning as pl
 from torch.nn import functional as F
-from torch.utils.data import DataLoader, random_split
+from torch.utils.data import DataLoader, data, random_split
 
 from torchvision.datasets.mnist import MNIST
 from torchvision import transforms
@@ -54,10 +54,10 @@ class LitClassifier(pl.LightningModule):
 
 class LitMNISTDataModule(pl.LightningDataModule):
 
-    def __init__(self, args):
+    def __init__(self, data_dir, batch_size):
         super().__init__()
-        self.data_dir = args.data_dir
-        self.batch_size = args.batch_size
+        self.data_dir = data_dir
+        self.batch_size = batch_size
 
         self.transform = transforms.Compose([transforms.ToTensor()])
 
@@ -96,7 +96,7 @@ def cli_main():
     # ------------
     # data
     # ------------
-    mnist = LitMNISTDataModule(args=args)
+    mnist = LitMNISTDataModule(args.data_dir, args.batch_size)
 
     # ------------
     # model

--- a/project/lit_mnist.py
+++ b/project/lit_mnist.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 import torch
 import pytorch_lightning as pl
 from torch.nn import functional as F
-from torch.utils.data import DataLoader, data, random_split
+from torch.utils.data import DataLoader, random_split
 
 from torchvision.datasets.mnist import MNIST
 from torchvision import transforms

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -13,4 +13,5 @@ def test_lit_classifier():
     trainer.fit(model, mnist)
 
     results = trainer.test(datamodule=mnist)
+
     assert results[0]['test_acc'] > 0.7

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,4 +1,5 @@
 from pytorch_lightning import Trainer, seed_everything
+from torch.utils import data
 from project.lit_mnist import LitClassifier
 from project.lit_mnist import LitMNISTDataModule
 
@@ -7,8 +8,7 @@ def test_lit_classifier():
     seed_everything(1234)
 
     model = LitClassifier()
-    args = {"batch_size": 32, "data_dir": ''}
-    mnist = LitMNISTDataModule(args)
+    mnist = LitMNISTDataModule(data_dir="", batch_size=32)
 
     trainer = Trainer(limit_train_batches=50, limit_val_batches=20, max_epochs=2)
     trainer.fit(model, mnist)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,5 +1,4 @@
 from pytorch_lightning import Trainer, seed_everything
-from torch.utils import data
 from project.lit_mnist import LitClassifier
 from project.lit_mnist import LitMNISTDataModule
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,15 +1,17 @@
 from pytorch_lightning import Trainer, seed_everything
 from project.lit_mnist import LitClassifier
-from project.datasets.mnist import mnist
+from project.lit_mnist import LitMNISTDataModule
 
 
 def test_lit_classifier():
     seed_everything(1234)
 
     model = LitClassifier()
-    train, val, test = mnist()
-    trainer = Trainer(limit_train_batches=50, limit_val_batches=20, max_epochs=2)
-    trainer.fit(model, train, val)
+    args = {"batch_size": 32, "data_dir": ''}
+    mnist = LitMNISTDataModule(args)
 
-    results = trainer.test(test_dataloaders=test)
+    trainer = Trainer(limit_train_batches=50, limit_val_batches=20, max_epochs=2)
+    trainer.fit(model, mnist)
+
+    results = trainer.test(datamodule=mnist)
     assert results[0]['test_acc'] > 0.7


### PR DESCRIPTION
I was trying to organize datasets and dataloaders (train, val, test) in LightningDataModule