### PR TITLE
Specifying hyperparameters in LitClassifier__init__()

### DIFF
--- a/project/lit_image_classifier.py
+++ b/project/lit_image_classifier.py
@@ -25,7 +25,9 @@ class Backbone(torch.nn.Module):
 class LitClassifier(pl.LightningModule):
     def __init__(self, backbone, learning_rate=1e-3):
         super().__init__()
-        self.save_hyperparameters()
+        # It's recomended to specify hyperparameters when using a backbone model.
+        # Specifically, avoid saving backbone model
+        self.save_hyperparameters(learning_rate)
         self.backbone = backbone
 
     def forward(self, x):


### PR DESCRIPTION
It is better to avoid using self.save_hyperparameters with no inputs as it will recorded backbone as part of the yaml file.
Doing do with simple resnet18 take about 2 minutes (probably to serialize the model)